### PR TITLE
Ensure the newly created window follows the main windows style and shut down engine when corresponding window close to reduce memory usage

### DIFF
--- a/multi_window_macos/macos/Classes/MultiWindowMacosPlugin.swift
+++ b/multi_window_macos/macos/Classes/MultiWindowMacosPlugin.swift
@@ -109,10 +109,8 @@ public class MultiWindowMacosPlugin: NSObject, FlutterPlugin {
 
         // Registering a channel first, before starting a new flutter project.
         registerEventChannel(key)
-
         let project = FlutterDartProject.init()
         project.dartEntrypointArguments = [key]
-
         let controller = MultiWindowViewController.init(project: project)
         controller.key = key
         registerGeneratedPlugins(controller)
@@ -120,7 +118,15 @@ public class MultiWindowMacosPlugin: NSObject, FlutterPlugin {
         let window = NSWindow()
         window.styleMask = mainWindow.styleMask
         window.backingType = mainWindow.backingType
-
+        window.titlebarAppearsTransparent = mainWindow.titlebarAppearsTransparent
+        window.titleVisibility = mainWindow.titleVisibility
+        if #available(macOS 10.13, *) {
+            window.toolbar = mainWindow.toolbar
+        }
+        if #available(macOS 11.0, *) {
+            window.toolbarStyle = mainWindow.toolbarStyle
+        }
+        window.isOpaque = mainWindow.isOpaque
         // Setup title.
         if let title = args["title"] as? String {
             window.title = title
@@ -188,7 +194,11 @@ public class MultiWindowMacosPlugin: NSObject, FlutterPlugin {
         windowController.shouldCascadeWindows = mainWindow.windowController?.shouldCascadeWindows ?? true
         windowController.window = window
         windowController.showWindow(self)
-
+        NSApp.activate(ignoringOtherApps: true)
+        window.center()
+        window.orderFront(self)
+        windowController.shouldCloseDocument = true
+//        window.isReleasedWhenClosed = true
         return result(nil)
     }
 
@@ -229,7 +239,7 @@ public class MultiWindowMacosPlugin: NSObject, FlutterPlugin {
         guard let key = arguments["key"] as? String else {
             return nil
         }
-
+        
         return windows.first(where: {($0.contentViewController as! MultiWindowViewController).key == key})
     }
 

--- a/multi_window_macos/macos/Classes/MultiWindowViewController.swift
+++ b/multi_window_macos/macos/Classes/MultiWindowViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FlutterMacOS
+import Cocoa
 
 public class MultiWindowViewController: FlutterViewController, NSWindowDelegate {
     var key: String = "main"
@@ -21,6 +22,19 @@ public class MultiWindowViewController: FlutterViewController, NSWindowDelegate 
                 MultiWindowMacosPlugin.multiEventSinks.removeValue(forKey: eventKey)
             }
         }
+        NotificationCenter.default.removeObserver(self, name: NSWindow.willCloseNotification, object: notification.object)
+    }
+    
+    public func windowShouldClose(_ sender: NSWindow) -> Bool {
+        //force deinit everything else and close the flutter engine
+        sender.contentViewController?.view.removeFromSuperview()
+        sender.contentViewController = nil
+        sender.windowController?.window = nil
+        sender.windowController = nil// will force deinit.
+        sender.delegate = nil
+        self.engine.viewController = nil
+        self.engine.shutDownEngine() //shut down the flutter engine to reduce memory usage after the window close
+        return true // allow to close.
     }
 
     private func emit(_ data: Any?) {


### PR DESCRIPTION
The added the WindowShouldClose listener to detect the window close event on macOS, one detected a window close, will then shut down the corresponding flutter engine to reduce memory usage

Also added some code to ensure the newly created window has the same style as the main window